### PR TITLE
Escaping 'trim' in `array_map`

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -68,7 +68,7 @@ class syntax_plugin_c3chart extends DokuWiki_Syntax_Plugin {
             }, $c3data
         ); // remove comments (respecting quoted strings)
         $c3data = explode("\n", $c3data);
-        $c3data = implode("", array_map(trim, $c3data));
+        $c3data = implode("", array_map('trim', $c3data));
         if($c3data[0]=='{') $c3data = substr($c3data, 1, -1);
         $chartid = uniqid('__c3chart_');
         $c3data = base64_encode('{"bindto": "#'.$chartid.'",'.$c3data.'}');


### PR DESCRIPTION
Escaping 'trim' in `array_map` (see [this SO thread](https://stackoverflow.com/questions/19272201/manage-array-of-functions-in-php))